### PR TITLE
Adjust conditions for first response

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -74,7 +74,7 @@ body:
         - Summary Statistics
         - T-Tests
         - Visual Modeling
-        - Other Module
+        - Other
     validations:
       required: true
   - type: input

--- a/.github/scripts/bug_firstResponse.js
+++ b/.github/scripts/bug_firstResponse.js
@@ -10,7 +10,7 @@ module.exports = async function ({github, context}) {
   const body = issue.data.body;
   // if any of these string are in the issue body, then there was a user upload, 
   // the first string covers all the image/video files
-  const regex = /user-images\.githubusercontent\.com|\.zip|\.rar|\.csv|\.sav|\.xlsx|\.xls|\.csv2/;
+  const regex = /(!\[.*?\])|\.zip|\.rar|\.csv|\.sav|\.xlsx|\.xls|\.csv2/;
   if (!regex.test(body)) {
     const comment = "@" + issue.data.user.login +
       ", thanks for taking the time to create this issue. \

--- a/.github/scripts/keywords.js
+++ b/.github/scripts/keywords.js
@@ -31,7 +31,7 @@ module.exports = function () {
       ["Summary Statistics","Module: jaspSummaryStatistics", "akashrajkn"],
       ["T-Tests","Module: jaspTTests", "vandenman"],
       ["Visual Modeling","Module: jaspVisualModeling", "dustinfife"],
-      ["Other Module", "", "Kucharssim"],
+      ["Other", "", "Kucharssim"],
       ["_No response_", "", "EJWagenmakers"]
     ], 
     oses: [


### PR DESCRIPTION
Unbeknownst to me the string that indicated a user uploaded an image to the issue body changed from something like `user-images.githubusercontent.com....`  something like `![Screenshot (148)](https://github.com/jasp-stats/jasp-issues/assets/135831484/2aeac12c-8667-4f02-be6b-29877b0c015d)`