### PR TITLE
fix user attachments first repsonse bug

### DIFF
--- a/.github/scripts/bug_firstResponse.js
+++ b/.github/scripts/bug_firstResponse.js
@@ -10,7 +10,7 @@ module.exports = async function ({github, context}) {
   const body = issue.data.body;
   // if any of these string are in the issue body, then there was a user upload, 
   // the first string covers all the image/video files
-  const regex = /(!\[.*?\])|\.zip|\.rar|\.csv|\.sav|\.xlsx|\.xls|\.csv2|\.pdf|\.docx/;
+  const regex = /user-attachments/;
   if (!regex.test(body)) {
     const comment = "@" + issue.data.user.login +
       ", thanks for taking the time to create this issue. \


### PR DESCRIPTION
the new check for the string "user-attachments" in the issue body seems more simple and works better than checking for the file endings

the previous approach hasn't worked for this issue: https://github.com/jasp-stats/jasp-issues/issues/2858